### PR TITLE
block GTID_SUBSET  sql injection

### DIFF
--- a/src/main/java/com/client9/libinjection/SQLParse.java
+++ b/src/main/java/com/client9/libinjection/SQLParse.java
@@ -8603,7 +8603,7 @@ for( int i = 0; i < 26; ++i )
         map.put("GROUPING", "f");
         map.put("GROUPING_ID", "f");
         map.put("GROUP_CONCAT", "f");
-	map.put("GTID_SUBSET", "f");
+        map.put("GTID_SUBSET", "f");
         map.put("HANDLER", "T");
         map.put("HASHBYTES", "f");
         map.put("HAS_PERMS_BY_NAME", "f");

--- a/src/main/java/com/client9/libinjection/SQLParse.java
+++ b/src/main/java/com/client9/libinjection/SQLParse.java
@@ -8603,6 +8603,7 @@ for( int i = 0; i < 26; ++i )
         map.put("GROUPING", "f");
         map.put("GROUPING_ID", "f");
         map.put("GROUP_CONCAT", "f");
+	map.put("GTID_SUBSET", "f");
         map.put("HANDLER", "T");
         map.put("HASHBYTES", "f");
         map.put("HAS_PERMS_BY_NAME", "f");


### PR DESCRIPTION
as issues 4
https://github.com/Kanatoko/libinjection-Java/issues/4

sqlmap 1.5  use GTID_SUBSET  function to injection

so we can block this function.