### PR TITLE
add JSON_KEYS function

### DIFF
--- a/src/main/java/com/client9/libinjection/SQLParse.java
+++ b/src/main/java/com/client9/libinjection/SQLParse.java
@@ -8686,6 +8686,7 @@ for( int i = 0; i < 26; ++i )
         map.put("IS_USED_LOCK", "f");
         map.put("ITERATE", "k");
         map.put("JOIN", "k");
+        map.put("JSON_KEYS", "f");
         map.put("JULIANDAY", "f");
         map.put("JUSTIFY_DAYS", "f");
         map.put("JUSTIFY_HOURS", "f");


### PR DESCRIPTION
'MySQL >= 5.7.8 error-based - ORDER BY, GROUP BY clause (JSON_KEYS)'
one of payload：
OR JSON_KEYS((SELECT CONVERT((SELECT CONCAT(0x71626b6b71,(SELECT (ELT(7360=7360,1))),0x717a626271)) USING utf8))) AND `dato`=`dato

i suggest add this lost function
thx